### PR TITLE
feat: rename columns

### DIFF
--- a/apps/api/src/app/accounts/schemas.ts
+++ b/apps/api/src/app/accounts/schemas.ts
@@ -5,7 +5,7 @@ import { ACCOUNT_TYPES } from '../../typeorm/account';
 export const create = {
   body: z
     .object({
-      number: z.number().positive(),
+      accountNumber: z.number().positive(),
       type: z.enum(ACCOUNT_TYPES),
       name: z.string().min(1).max(255),
       description: z.string().max(2048).optional(),

--- a/apps/api/src/app/transactions/controller.ts
+++ b/apps/api/src/app/transactions/controller.ts
@@ -53,7 +53,7 @@ export class TransactionsController {
             amount: entry.amount.toString(),
 
             transactionId,
-            accountNumber: entry.accountNo,
+            accountNumber: entry.accountNumber,
           })
         );
 

--- a/apps/api/src/app/transactions/controller.ts
+++ b/apps/api/src/app/transactions/controller.ts
@@ -15,7 +15,6 @@ import { Transaction } from '../../typeorm/transaction';
 import { TransactionEntry } from '../../typeorm/transaction-entry';
 
 import * as schemas from './schemas';
-import { CreateTransactionResponse } from './types';
 
 @Controller()
 export class TransactionsController {

--- a/apps/api/src/app/transactions/controller.ts
+++ b/apps/api/src/app/transactions/controller.ts
@@ -54,7 +54,7 @@ export class TransactionsController {
             amount: entry.amount.toString(),
 
             transactionId,
-            accountNo: entry.accountNo,
+            accountNumber: entry.accountNo,
           })
         );
 

--- a/apps/api/src/app/transactions/schemas.ts
+++ b/apps/api/src/app/transactions/schemas.ts
@@ -15,7 +15,7 @@ export const create = {
       entries: z
         .array(
           z.object({
-            accountNo: z.number().positive(),
+            accountNumber: z.number().positive(),
             amount: z
               .string()
               .transform((s) => new BigNumber(s))

--- a/apps/api/src/app/transactions/types.ts
+++ b/apps/api/src/app/transactions/types.ts
@@ -1,4 +1,0 @@
-export interface CreateTransactionResponse {
-  id: number;
-  entries: { id: string }[];
-}

--- a/apps/api/src/typeorm/account.ts
+++ b/apps/api/src/typeorm/account.ts
@@ -14,8 +14,8 @@ export const ACCOUNT_TYPES = [
 
 @Entity('account')
 export class Account {
-  @PrimaryColumn({ type: 'integer' })
-  number: number;
+  @PrimaryColumn({ name: 'account_number', type: 'integer' })
+  accountNumber: number;
 
   @Column({
     type: 'enum',

--- a/apps/api/src/typeorm/transaction-entry.ts
+++ b/apps/api/src/typeorm/transaction-entry.ts
@@ -13,8 +13,11 @@ import { Transaction } from './transaction';
 
 @Entity('transaction_entry')
 export class TransactionEntry {
-  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
-  id: string;
+  @PrimaryGeneratedColumn('increment', {
+    name: 'transaction_entry_id',
+    type: 'bigint',
+  })
+  transactionEntryId: string;
 
   @Column({ type: 'text', nullable: true })
   description: string;
@@ -44,13 +47,16 @@ export class TransactionEntry {
   transactionId: bigint;
 
   @ManyToOne(() => Transaction, (transaction) => transaction.entries)
-  @JoinColumn({ name: 'transaction_id', referencedColumnName: 'id' })
+  @JoinColumn({
+    name: 'transaction_id',
+    referencedColumnName: 'transactionId',
+  })
   transaction: Transaction;
 
-  @Column({ name: 'account_no', type: 'int', nullable: false })
-  accountNo: number;
+  @Column({ name: 'account_number', type: 'int', nullable: false })
+  accountNumber: number;
 
   @ManyToOne(() => Account, (account) => account.entries)
-  @JoinColumn({ name: 'account_no', referencedColumnName: 'number' })
+  @JoinColumn({ name: 'account_number', referencedColumnName: 'accountNumber' })
   account: Account;
 }

--- a/apps/api/src/typeorm/transaction.ts
+++ b/apps/api/src/typeorm/transaction.ts
@@ -10,8 +10,11 @@ import { TransactionEntry } from './transaction-entry';
 
 @Entity('transaction')
 export class Transaction {
-  @PrimaryGeneratedColumn('increment', { type: 'bigint' })
-  id: string;
+  @PrimaryGeneratedColumn('increment', {
+    name: 'transaction_id',
+    type: 'bigint',
+  })
+  transactionId: bigint;
 
   @Column({ type: 'text', nullable: false })
   name: string;

--- a/apps/db/deploy/20250119_rename_columns.sql
+++ b/apps/db/deploy/20250119_rename_columns.sql
@@ -1,0 +1,75 @@
+BEGIN;
+
+-- Rename primary keys
+
+ALTER TABLE account
+    RENAME COLUMN number TO account_number;
+
+ALTER TABLE currency
+    RENAME COLUMN code TO currency_code;
+
+ALTER TABLE transaction
+    RENAME COLUMN id TO transaction_id;
+
+ALTER TABLE transaction_entry
+    RENAME COLUMN id TO transaction_entry_id;
+
+-- Rename foreign keys
+
+ALTER TABLE transaction_entry
+    RENAME COLUMN account_no TO account_number;
+
+-- Rename new references in the check_transaction_is_balanced function
+
+CREATE OR REPLACE FUNCTION check_transaction_is_balanced() RETURNS TRIGGER AS
+$$
+BEGIN
+    CREATE TEMP TABLE transactions_to_check
+    (
+        transaction_id BIGINT
+    ) ON COMMIT DROP;
+
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            new_table;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            new_table;
+    ELSIF (TG_OP = 'DELETE') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            old_table;
+    END IF;
+
+    PERFORM
+        t.transaction_id, a.currency_code
+    FROM
+        transactions_to_check ttc
+            JOIN transaction t USING (transaction_id)
+            JOIN transaction_entry te USING (transaction_id)
+            JOIN account a USING (account_number)
+    GROUP BY
+        t.transaction_id, a.currency_code
+    HAVING
+        SUM(te.amount) != 0;
+
+    IF FOUND THEN
+        RAISE check_violation USING MESSAGE = 'Transactions are not balanced';
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/apps/db/revert/20250119_rename_columns.sql
+++ b/apps/db/revert/20250119_rename_columns.sql
@@ -1,0 +1,75 @@
+BEGIN;
+
+-- Rename old references in the check_transaction_is_balanced function
+
+CREATE OR REPLACE FUNCTION check_transaction_is_balanced() RETURNS TRIGGER AS
+$$
+BEGIN
+    CREATE TEMP TABLE transactions_to_check
+    (
+        transaction_id BIGINT
+    ) ON COMMIT DROP;
+
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            new_table;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            new_table;
+    ELSIF (TG_OP = 'DELETE') THEN
+        INSERT INTO
+            transactions_to_check
+        SELECT DISTINCT
+            transaction_id
+        FROM
+            old_table;
+    END IF;
+
+    PERFORM
+        t.id, a.currency_code
+    FROM
+        transactions_to_check ttc
+            JOIN transaction t ON (ttc.transaction_id = t.id)
+            JOIN transaction_entry te ON (t.id = te.transaction_id)
+            JOIN account a ON (te.account_no = a.number)
+    GROUP BY
+        t.id, a.currency_code
+    HAVING
+        SUM(te.amount) != 0;
+
+    IF FOUND THEN
+        RAISE check_violation USING MESSAGE = 'Transactions are not balanced';
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Rename foreign keys
+
+ALTER TABLE transaction_entry
+    RENAME COLUMN account_number TO account_no;
+
+-- Rename primary keys
+
+ALTER TABLE transaction_entry
+    RENAME COLUMN transaction_entry_id TO id;
+
+ALTER TABLE transaction
+    RENAME COLUMN transaction_id TO id;
+
+ALTER TABLE currency
+    RENAME COLUMN currency_code TO code;
+
+ALTER TABLE account
+    RENAME COLUMN account_number TO number;
+
+COMMIT;

--- a/apps/db/sqitch.plan
+++ b/apps/db/sqitch.plan
@@ -6,3 +6,4 @@
 20241110_add_account_currency 2024-11-10T22:12:40Z Manuel Pacheco <contact@manuelpacheco.dev> # Add account currency
 20241111_update_entry_fks 2024-11-11T00:36:15Z Manuel Pacheco <contact@manuelpacheco.dev> # Update entry fks
 20241112_check_transaction_is_balanced 2024-11-11T02:58:50Z Manuel Pacheco <contact@manuelpacheco.dev> # Check transaction is balanced
+20250119_rename_columns 2025-01-19T11:21:53Z Manuel Pacheco <contact@manuelpacheco.dev> # rename columns

--- a/apps/db/verify/20250119_rename_columns.sql
+++ b/apps/db/verify/20250119_rename_columns.sql
@@ -1,0 +1,63 @@
+BEGIN;
+
+DO
+$$
+    BEGIN
+        -- account has account_number
+        ASSERT (
+            SELECT
+                TRUE
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 'account'
+                AND column_name = 'account_number'
+        );
+
+        -- currency has currency_code
+        ASSERT (
+            SELECT
+                TRUE
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 'currency'
+                AND column_name = 'currency_code'
+        );
+
+        -- transaction has transaction_id
+        ASSERT (
+            SELECT
+                TRUE
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 'transaction'
+                AND column_name = 'transaction_id'
+        );
+
+        -- transaction_entry has transaction_entry_id
+        ASSERT (
+            SELECT
+                TRUE
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 'transaction_entry'
+                AND column_name = 'transaction_entry_id'
+        );
+
+        -- transaction_entry has account_number
+        ASSERT (
+            SELECT
+                TRUE
+            FROM
+                information_schema.columns
+            WHERE
+                table_name = 'transaction_entry'
+                AND column_name = 'transaction_entry_id'
+        );
+    END
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Updates database column using the table name as prefix for the identifier (if it has).

This helps with foreign keys having the same name, making joins (and mental relations) easier.